### PR TITLE
Flag to manually list the repos to sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ GITHUB_OWNER=
 GITHUB_USERNAME=
 GITHUB_MAIL=
 GITHUB_TOKEN=
+
+EXCLUDE_REPOSITORIES_LIST=repo-one,repo-two,repo-three # flag which repositories to exclude from sync
+ONLY_INCLUDE_REPOSITORIES_LIST=repo-four,repo-five # setting this will ignore all repositories except these

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,6 +48,26 @@ async function makeRequest(method, url, headers, body) {
     }
 }
 
+function mapReposFromEnv(envRepoList) {
+  let exclude = {};
+
+  if (envRepoList) {
+      const repoArray = envRepoList.split(',');
+
+      exclude = repoArray.reduce((map, repoName) => {
+          map[repoName.trim()] = true; // Tags it as true
+          return map;
+      }, {});
+  } else {
+    return false;
+  }
+  return exclude;
+}
+
+function isRepoExcluded(list, repoName) {
+    return !!list[repoName];
+}
+
 module.exports = {
-    makeRequest
+    makeRequest, mapReposFromEnv, isRepoExcluded
 }


### PR DESCRIPTION
Added an option/flag to manually list the repos to sync, as reported by [Fmacmak](https://github.com/Fmacmak) commented [on May 1](https://github.com/SV3A/bBucket2gHub/issues/10#issue-2272419335).

Controlled by adding the repositories that you want to include or exclude in the env file.